### PR TITLE
Fixed auto-generated test case class name in Gii template generator for case search parameters.

### DIFF
--- a/protected/config/core/common.php
+++ b/protected/config/core/common.php
@@ -65,7 +65,10 @@ return array(
                 'PatientMedication',
                 'PreviousTrial',
                 'PatientAllergy',
-                'FamilyHistory'
+                'FamilyHistory',
+            ),
+            'fixedParameters' => array(
+                'PatientDeceased'
             ),
             'providers' => array(
                 'mysql' => 'DBProvider'

--- a/protected/gii/CaseSearchParameter/CaseSearchParameterCode.php
+++ b/protected/gii/CaseSearchParameter/CaseSearchParameterCode.php
@@ -37,7 +37,7 @@ class CaseSearchParameterCode extends CCodeModel
     {
         $parameterPath = Yii::getPathOfAlias('application.modules.OECaseSearch.models.' . $this->className) . 'Parameter.php';
         $parameterCode = $this->render($this->templatePath.'/case_search_parameter.php');
-        $testPath = Yii::getPathOfAlias('application.modules.OECaseSearch.tests.unit.models.' . $this->className) . 'Test.php';
+        $testPath = Yii::getPathOfAlias('application.modules.OECaseSearch.tests.unit.models.' . $this->className) . 'ParameterTest.php';
         $testCode = $this->render($this->templatePath.'/case_search_parameter_test.php');
         $this->files[] = new CCodeFile($parameterPath, $parameterCode);
         $this->files[] = new CCodeFile($testPath, $testCode);


### PR DESCRIPTION
Added a single fixed parameter, PatientDeceased - See OECaseSearch repository for details.

TODO: Move the OECaseSearch config to a module-specific config file to prevent commit dependencies.
Fixed auto-generated test case class name in Gii template generator for case search parameters.