### PR TITLE
Fixed Unconfirmed Diagnoses Not Being Set

### DIFF
--- a/protected/controllers/PatientController.php
+++ b/protected/controllers/PatientController.php
@@ -759,12 +759,16 @@ class PatientController extends BaseController
 
         $date = $this->processFuzzyDate();
 
+        // If the patient came  from a referral or self registration, then the diagnosis is unconfirmed
+        $is_confirmed = ($patient->patient_source == Patient::PATIENT_SOURCE_REFERRAL
+            || $patient->patient_source == Patient::PATIENT_SOURCE_SELF_REGISTER) ? 0 : null;
+
         if (!$_POST['diagnosis_eye']) {
             if (!SecondaryDiagnosis::model()->find('patient_id=? and disorder_id=? and date=?', array($patient->id, $disorder->id, $date))) {
-                $patient->addDiagnosis($disorder->id, null, $date);
+                $patient->addDiagnosis($disorder->id, null, $date, $is_confirmed);
             }
         } elseif (!SecondaryDiagnosis::model()->find('patient_id=? and disorder_id=? and eye_id=? and date=?', array($patient->id, $disorder->id, $_POST['diagnosis_eye'], $date))) {
-            $patient->addDiagnosis($disorder->id, $_POST['diagnosis_eye'], $date);
+            $patient->addDiagnosis($disorder->id, $_POST['diagnosis_eye'], $date, $is_confirmed);
         }
 
         $this->redirect(array('patient/view/'.$patient->id));
@@ -789,10 +793,6 @@ class PatientController extends BaseController
         $sd->date = $this->processFuzzyDate();
         $sd->disorder_id = @$disorder_id;
         $sd->eye_id = @$_POST['diagnosis_eye'];
-
-        // If the patient came  from a referral or self registration, then the diagnosis is unconfirmed
-        $sd->is_confirmed = $patient->patient_source == Patient::PATIENT_SOURCE_REFERRAL
-                         || $patient->patient_source == Patient::PATIENT_SOURCE_SELF_REGISTER ? 0 : null;
 
         $errors = array();
 

--- a/protected/models/Patient.php
+++ b/protected/models/Patient.php
@@ -1359,7 +1359,7 @@ class Patient extends BaseActiveRecordVersioned
         return $codes;
     }
 
-    public function addDiagnosis($disorder_id, $eye_id = false, $date = false)
+    public function addDiagnosis($disorder_id, $eye_id = false, $date = false, $is_confirmed = null)
     {
         if (!$date) {
             $date = date('Y-m-d');
@@ -1382,6 +1382,7 @@ class Patient extends BaseActiveRecordVersioned
             $sd->disorder_id = $disorder_id;
             $sd->eye_id = $eye_id;
             $sd->date = $date;
+            $sd->is_confirmed = $is_confirmed;
 
             // If the patient came  from a referral or self registration, then the diagnosis is unconfirmed
             $sd->is_confirmed = $this->patient_source == Patient::PATIENT_SOURCE_REFERRAL


### PR DESCRIPTION
Fixed an issue where patient diagnoses were not correctly being set to unconfirmed if the patient source was set to Referral or Self-Registration