### PR TITLE
All newly added diagnoses are now always marked as unconfirmed, regardless of patient source.

### DIFF
--- a/protected/controllers/PatientController.php
+++ b/protected/controllers/PatientController.php
@@ -760,15 +760,12 @@ class PatientController extends BaseController
 
         $date = $this->processFuzzyDate();
 
-        // Mark diagnosis as unconfirmed, regardless of patient source.
-        $is_confirmed = 0;
-
         if (!$_POST['diagnosis_eye']) {
             if (!SecondaryDiagnosis::model()->find('patient_id=? and disorder_id=? and date=?', array($patient->id, $disorder->id, $date))) {
-                $patient->addDiagnosis($disorder->id, null, $date, $is_confirmed);
+                $patient->addDiagnosis($disorder->id, null, $date);
             }
         } elseif (!SecondaryDiagnosis::model()->find('patient_id=? and disorder_id=? and eye_id=? and date=?', array($patient->id, $disorder->id, $_POST['diagnosis_eye'], $date))) {
-            $patient->addDiagnosis($disorder->id, $_POST['diagnosis_eye'], $date, $is_confirmed);
+            $patient->addDiagnosis($disorder->id, $_POST['diagnosis_eye'], $date);
         }
 
         $this->redirect(array('patient/view/'.$patient->id));

--- a/protected/controllers/PatientController.php
+++ b/protected/controllers/PatientController.php
@@ -760,9 +760,8 @@ class PatientController extends BaseController
 
         $date = $this->processFuzzyDate();
 
-        // If the patient came  from a referral or self registration, then the diagnosis is unconfirmed
-        $is_confirmed = ($patient->patient_source == Patient::PATIENT_SOURCE_REFERRAL
-            || $patient->patient_source == Patient::PATIENT_SOURCE_SELF_REGISTER) ? 0 : null;
+        // Mark diagnosis as unconfirmed, regardless of patient source.
+        $is_confirmed = 0;
 
         if (!$_POST['diagnosis_eye']) {
             if (!SecondaryDiagnosis::model()->find('patient_id=? and disorder_id=? and date=?', array($patient->id, $disorder->id, $date))) {

--- a/protected/models/Patient.php
+++ b/protected/models/Patient.php
@@ -1452,10 +1452,6 @@ class Patient extends BaseActiveRecordVersioned
             $sd->date = $date;
             $sd->is_confirmed = $is_confirmed;
 
-            // If the patient came  from a referral or self registration, then the diagnosis is unconfirmed
-            $sd->is_confirmed = $this->patient_source == Patient::PATIENT_SOURCE_REFERRAL
-            || $this->patient_source == Patient::PATIENT_SOURCE_SELF_REGISTER ? 0 : null;
-
             if (!$sd->save()) {
                 throw new Exception('Unable to save secondary diagnosis: '.print_r($sd->getErrors(), true));
             }

--- a/protected/models/Patient.php
+++ b/protected/models/Patient.php
@@ -1427,7 +1427,7 @@ class Patient extends BaseActiveRecordVersioned
         return $codes;
     }
 
-    public function addDiagnosis($disorder_id, $eye_id = false, $date = false, $is_confirmed = null)
+    public function addDiagnosis($disorder_id, $eye_id = false, $date = false)
     {
         if (!$date) {
             $date = date('Y-m-d');
@@ -1450,7 +1450,7 @@ class Patient extends BaseActiveRecordVersioned
             $sd->disorder_id = $disorder_id;
             $sd->eye_id = $eye_id;
             $sd->date = $date;
-            $sd->is_confirmed = $is_confirmed;
+            $sd->is_confirmed = 0;
 
             if (!$sd->save()) {
                 throw new Exception('Unable to save secondary diagnosis: '.print_r($sd->getErrors(), true));

--- a/protected/views/patient/_130_diagnoses.php
+++ b/protected/views/patient/_130_diagnoses.php
@@ -40,6 +40,7 @@
 				<th>Diagnosis</th>
 				<?php if ($this->checkAccess('OprnEditOtherOphDiagnosis')) { ?>
 					<th>Actions</th>
+                    <th/>
 				<?php } ?>
 			</tr>
 			</thead>
@@ -54,13 +55,15 @@
 					}
 					?>
 					<td><?php echo $diagnosis->dateText?></td>
-					<td><?php echo $term . ($diagnosis->isConfirmed() ? ' (Unconfirmed)' : ''); ?></td>
+					<td><?php echo $term . ($diagnosis->isUnconfirmed() ? ' (Unconfirmed)' : ''); ?></td>
 					<?php if ($this->checkAccess('OprnEditOtherOphDiagnosis')) { ?>
 						<td><a href="#" class="removeDiagnosis" rel="<?php echo $diagnosis->id?>">Remove</a></td>
-                        <?php if ($diagnosis->isUnconfirmed() === 0): ?>
+                        <?php if ($diagnosis->isUnconfirmed()): ?>
                             <td>
                                 <a href="#" class="confirmDiagnosis" rel="<?php echo $diagnosis->id?>">Confirm</a>
                             </td>
+                        <?php else: ?>
+                            <td/>
                         <?php endif; ?>
 					<?php } ?>
 				</tr>

--- a/protected/views/patient/_130_diagnoses.php
+++ b/protected/views/patient/_130_diagnoses.php
@@ -40,7 +40,7 @@
 				<th>Diagnosis</th>
 				<?php if ($this->checkAccess('OprnEditOtherOphDiagnosis')) { ?>
 					<th>Actions</th>
-                    <th/>
+                    <th></th>
 				<?php } ?>
 			</tr>
 			</thead>
@@ -63,7 +63,7 @@
                                 <a href="#" class="confirmDiagnosis" rel="<?php echo $diagnosis->id?>">Confirm</a>
                             </td>
                         <?php else: ?>
-                            <td/>
+                            <td></td>
                         <?php endif; ?>
 					<?php } ?>
 				</tr>


### PR DESCRIPTION
Fixed issue where pre-existing diagnoses were being marked as unconfirmed despite actually being confirmed.
Fixed display issue with confirm link column.