### PR TITLE
"Username already Exists" Validation Error FIx

### DIFF
--- a/protected/models/User.php
+++ b/protected/models/User.php
@@ -75,7 +75,16 @@ class User extends BaseActiveRecordVersioned
     {
         $commonRules = array(
             // Added for uniqueness of username
-            array('username', 'unique', 'className' => 'User', 'attributeName' => 'username'),
+            array(
+                'username',
+                'unique',
+                'className' => 'User',
+                'attributeName' => 'username',
+                'criteria' => array( // Ignore the username of the existing row when updating a record
+                    'condition' => 'id != :new_id OR :new_id IS NULL',
+                    'params' => array(':new_id' => $this->id),
+                ),
+            ),
             array('id, username, first_name, last_name, email, active, global_firm_rights', 'safe', 'on' => 'search'),
             array(
                 'username, first_name, last_name, email, active, global_firm_rights, is_doctor, title, qualifications, role, salt, password, is_clinical, is_consultant, is_surgeon,


### PR DESCRIPTION
Fixed an issue where attempting to update an existing user record would fail validation because the username is already being "used" by the record that is being updated