### PR TITLE
Date of Birth Range Validation Fixes

### DIFF
--- a/protected/migrations/m170823_064156_cera_ethnic_groups.php
+++ b/protected/migrations/m170823_064156_cera_ethnic_groups.php
@@ -19,7 +19,7 @@ class m170823_064156_cera_ethnic_groups extends OEMigration
         foreach ($patients as $patient) {
             $patient->ethnic_group_id = 16;
             if (!$patient->save()) {
-                throw new CDbException("Unable to save patient $patient->id");
+                throw new CDbException("Unable to save patient $patient->id: " . print_r($patient->getErrors(),true));
             }
         }
 

--- a/protected/models/Patient.php
+++ b/protected/models/Patient.php
@@ -130,10 +130,10 @@ class Patient extends BaseActiveRecordVersioned
             array('gender', 'required', 'on' => 'self_register'),
             array('gp_id', 'required', 'on' => 'referral'),
             array('deleted', 'safe'),
-            array('dob', 'dateFormatValidator', 'on' => 'manual'),
-            array('date_of_death', 'deathDateFormatValidator', 'on' => 'manual'),
+            array('dob', 'dateFormatValidator', 'on' => array('manual', 'self_register', 'referral', 'other_register')),
+            array('date_of_death', 'deathDateFormatValidator', 'on' => array('manual', 'self_register', 'referral', 'other_register')),
             array('dob, hos_num, nhs_num, date_of_death, deleted,is_local, patient_source', 'safe', 'on' => 'search'),
-            array('dob','checkdate'),
+            array('dob','dateOfBirthRangeValidator', 'on' => array('manual', 'self_register', 'referral', 'other_register')),
         );
     }
 
@@ -2159,12 +2159,17 @@ class Patient extends BaseActiveRecordVersioned
         return false;
     }
 
-    public function checkdate($attribute,$params)
+    public function dateOfBirthRangeValidator($attribute, $params)
     {
-        $currentdate = new DateTime(date("j M Y"));
+        if ($this->hasErrors('dob')) {
+            return;
+        }
+
+        $currentDate = new DateTime(date('j M Y'));
         $date_of_birth = new DateTime($this->dob);
-        if($date_of_birth > $currentdate || $this->getAge() > 100) {
-            $this->addError($attribute,"Date of Birth is not in the reasonable date range");
+
+        if ($date_of_birth > $currentDate || $this->getAge() > 100) {
+            $this->addError($attribute,'Date of Birth is not in the reasonable date range');
         }
 
     }


### PR DESCRIPTION
Fixed an issue with the date of birth range validator where it would prevent patients that are added via a PAS (or via the dummy data) from being saved; where the range validator would crash if the format was incorrect; and where the date format validator was not being run when the patient source was used