### PR TITLE
Patient Form AJAX Validation Fix

### DIFF
--- a/protected/controllers/PatientController.php
+++ b/protected/controllers/PatientController.php
@@ -1880,19 +1880,19 @@ class PatientController extends BaseController
         Yii::app()->request->sendFile($model->file_name, $model->file_content, $model->file_type, true);
     }
 
-    public function actionFindDuplicates($firstName, $surname, $dob, $id = null)
+    public function actionFindDuplicates($firstName, $last_name, $dob, $id = null)
     {
-        $patients = Patient::findDuplicates($firstName, $surname, $dob, $id);
+        $patients = Patient::findDuplicates($firstName, $last_name, $dob, $id);
 
         if (count($patients) !== 0) {
             $this->renderPartial('crud/_conflicts', array(
                 'patients' => $patients,
-                'name' => $firstName . ' ' . $surname
+                'name' => $firstName . ' ' . $last_name
             ));
         }
         else {
             $this->renderPartial('crud/_conflicts', array(
-                'name' => $firstName . ' ' . $surname
+                'name' => $firstName . ' ' . $last_name
             ));
         }
     }

--- a/protected/models/Patient.php
+++ b/protected/models/Patient.php
@@ -2177,12 +2177,12 @@ class Patient extends BaseActiveRecordVersioned
     /**
      * Find all patients with the same date of birth and similar-sounding names.
      * @param $firstName string First name.
-     * @param $surname string Last name.
+     * @param $last_name string Last name.
      * @param $dob string Date of Birth (DD/MM/YYYY).
      * @param $id int ID of the current patient record.
      * @return array|Patient[] The list of patients who have similar names and the same date of birth.
      */
-    public static function findDuplicates($firstName, $surname, $dob, $id)
+    public static function findDuplicates($firstName, $last_name, $dob, $id)
     {
         $sql = '
         SELECT p.*
@@ -2198,6 +2198,6 @@ class Patient extends BaseActiveRecordVersioned
 
         $mysqlDob = Helper::convertNHS2MySQL(date('d M Y', strtotime(str_replace('/', '-', $dob))));
 
-        return Patient::model()->findAllBySql($sql, array(':dob' => $mysqlDob, ':first_name' => $firstName, ':last_name' => $surname, ':id' => $id));
+        return Patient::model()->findAllBySql($sql, array(':dob' => $mysqlDob, ':first_name' => $firstName, ':last_name' => $last_name, ':id' => $id));
     }
 }

--- a/protected/views/patient/crud/_form.php
+++ b/protected/views/patient/crud/_form.php
@@ -561,12 +561,15 @@ $ethnic_groups = CHtml::listData(EthnicGroup::model()->findAll(), 'id', 'name');
 
 <script type="text/javascript">
   function findDuplicates(id) {
-    if ($("#Contact_first_name").val() && $('#Contact_last_name').val() && $('#Patient_dob').val()) {
+    var first_name = $('#Contact_first_name').val();
+    var last_name = $('#Contact_last_name').val();
+    var date_of_birth = $('#Patient_dob').val();
+    if (first_name && last_name && date_of_birth) {
       $.ajax({
           url: "<?php echo Yii::app()->controller->createUrl('patient/findDuplicates'); ?>",
-          data: {firstName: $('#Contact_first_name').val(), surname: $('#Contact_last_name').val(), dob: $('#Patient_dob').val(), id: id},
+          data: {firstName: first_name, last_name: last_name, dob: date_of_birth, id: id},
           type: 'GET',
-          success: function(response) {
+          success: function (response) {
             $('#conflicts').remove();
             $('#contact').after(response);
           }

--- a/protected/views/patient/crud/_form.php
+++ b/protected/views/patient/crud/_form.php
@@ -96,7 +96,7 @@ $ethnic_groups = CHtml::listData(EthnicGroup::model()->findAll(), 'id', 'name');
       <div class="row field-row">
         <div class="large-5 column"><?php echo $form->labelEx($contact, 'first_name'); ?></div>
         <div class="large-4 column end">
-          <?php echo $form->textField($contact, 'first_name', array('size' => 40, 'maxlength' => 40, 'id' => 'fname', 'onblur' => "findDuplicates($patient->id);")); ?>
+          <?php echo $form->textField($contact, 'first_name', array('size' => 40, 'maxlength' => 40, 'onblur' => "findDuplicates($patient->id);")); ?>
           <?php echo $form->error($contact, 'first_name'); ?>
         </div>
       </div>
@@ -104,7 +104,7 @@ $ethnic_groups = CHtml::listData(EthnicGroup::model()->findAll(), 'id', 'name');
       <div class="row field-row">
         <div class="large-5 column"><?php echo $form->labelEx($contact, 'last_name'); ?></div>
         <div class="large-4 column end">
-          <?php echo $form->textField($contact, 'last_name', array('size' => 40, 'maxlength' => 40, 'id' => 'surname', 'onblur' => "findDuplicates($patient->id);")); ?>
+          <?php echo $form->textField($contact, 'last_name', array('size' => 40, 'maxlength' => 40, 'onblur' => "findDuplicates($patient->id);")); ?>
           <?php echo $form->error($contact, 'last_name'); ?>
         </div>
       </div>
@@ -561,10 +561,10 @@ $ethnic_groups = CHtml::listData(EthnicGroup::model()->findAll(), 'id', 'name');
 
 <script type="text/javascript">
   function findDuplicates(id) {
-    if ($("#fname").val() && $('#surname').val() && $('#Patient_dob').val()) {
+    if ($("#Contact_first_name").val() && $('#Contact_last_name').val() && $('#Patient_dob').val()) {
       $.ajax({
           url: "<?php echo Yii::app()->controller->createUrl('patient/findDuplicates'); ?>",
-          data: {firstName: $('#fname').val(), surname: $('#surname').val(), dob: $('#Patient_dob').val(), id: id},
+          data: {firstName: $('#Contact_first_name').val(), surname: $('#Contact_last_name').val(), dob: $('#Patient_dob').val(), id: id},
           type: 'GET',
           success: function(response) {
             $('#conflicts').remove();


### PR DESCRIPTION
Fixed an issue where the AJAX validation of the patient first/last names was not working due to the ID of the field being manually set (causing the onchange event to not be attached)