### PR TITLE
Custom Report Filenames

### DIFF
--- a/protected/controllers/BaseReportController.php
+++ b/protected/controllers/BaseReportController.php
@@ -74,7 +74,7 @@ class BaseReportController extends BaseController
     protected function sendCsvHeaders($filename)
     {
         header('Content-type: text/csv');
-        header("Content-Disposition: attachment; filename=$filename");
+        header('Content-Disposition: attachment; filename="' . utf8_decode($filename) . '"');
         header('Pragma: no-cache');
         header('Expires: 0');
     }
@@ -111,7 +111,18 @@ class BaseReportController extends BaseController
 
     public function actionDownloadReport()
     {
-        $this->sendCsvHeaders($_POST['report-name'].'.csv');
+        if (isset($_POST['report-filename'])) {
+            $report_filename = $_POST['report-filename'];
+
+            // sanitise filename
+            $report_filename = mb_ereg_replace("([^\w\s\d\-_~,;\[\]\(\).])", '', $report_filename);
+            // Remove any runs of full stops
+            $report_filename = mb_ereg_replace("([\.]{2,})", '', $report_filename);
+        } else {
+            $report_filename = $_POST['report-name'];
+        }
+
+        $this->sendCsvHeaders($report_filename . '.csv');
 
         if ($this->module) {
             $report_class = $this->module->id.'_Report'.$_POST['report-name'];


### PR DESCRIPTION
Changed reports to use 'report-filename' post parameter as the name of the csv file if it exists. If not, then the model name will be used