### PR TITLE
Changed delete button to not append and delete an s

### DIFF
--- a/protected/assets/js/handleButtons.js
+++ b/protected/assets/js/handleButtons.js
@@ -72,18 +72,15 @@ $(document).ready(function(){
       uri,
       serializedForm,
       $form;
-
+    object = null;
     if ($(e.target).data('object')) {
       object = $(e.target).data('object');
-      if (object.charAt(object.length - 1) !== 's') {
-        object = object + 's';
-      }
     } else {
       hrefArray = window.location.href.split('?')[0].split('/');
 
       for (var i = 0; i < hrefArray.length; i++) {
         if (hrefArray[i] === 'admin') {
-          object = hrefArray[parseInt(i) + 1].replace(/s$/, '');
+          object = hrefArray[parseInt(i) + 1];
         }
       }
     }


### PR DESCRIPTION
The delete button on the admin screens (and some others) used to append an s onto the object name and  then delete it to produce the uri for the POST that actually deletes the file. This didn't work in all cases and it's silly to begin with so it's gone