### PR TITLE
Fixed Patient Medication parameter errors due to v2 migration.

### DIFF
--- a/protected/models/Patient.php
+++ b/protected/models/Patient.php
@@ -166,6 +166,12 @@ class Patient extends BaseActiveRecordVersioned
             'allergies' => array(self::MANY_MANY, 'Allergy', 'patient_allergy_assignment(patient_id, allergy_id)',
                 'alias' => 'patient_allergies',
                 'order' => 'patient_allergies.name', ),
+            'medications' => array(self::MANY_MANY, '\OEModule\OphCiExamination\models\HistoryMedicationsEntry', 'patient_medication_assignment(patient_id, id)',
+                'alias' => 'patient_medications',
+                'order' => 'patient_medications.medication_name', ),
+            'diagnoses' => array(self::MANY_MANY, '\OEModule\OphCiExamination\models\OphCiExamination_Diagnosis', 'patient_diagnosis_assignment(patient_id, id)',
+                'alias' => 'patient_diagnoses',
+                'order' => 'patient_diagnoses.principal DESC', ),
             'allergyAssignments' => array(self::HAS_MANY, 'PatientAllergyAssignment', 'patient_id'),
             'referral' => array(self::HAS_ONE, 'PatientReferral', 'patient_id'),
             'risks' => array(

--- a/protected/models/PatientDiagnosisParameter.php
+++ b/protected/models/PatientDiagnosisParameter.php
@@ -107,20 +107,27 @@ class PatientDiagnosisParameter extends CaseSearchParameter implements DBProvide
     {
         $query = "SELECT DISTINCT p.id 
 FROM patient p 
-LEFT JOIN secondary_diagnosis sd 
-  ON sd.patient_id = p.id 
-LEFT JOIN episode ep
-  ON ep.patient_id = p.id
+LEFT JOIN patient_diagnosis_assignment paa
+  ON paa.patient_id = p.id
 LEFT JOIN disorder d 
-  ON (d.id = sd.disorder_id OR d.id = ep.disorder_id)
+  ON d.id = paa.disorder_id
 WHERE LOWER(d.term) LIKE LOWER(:p_d_value_$this->id)";
         if ($this->firm_id !== '' && $this->firm_id !== null) {
             $query = "SELECT DISTINCT p.id 
 FROM patient p 
-JOIN episode ep
-  ON ep.patient_id = p.id
-JOIN disorder d 
-  ON (d.id = ep.disorder_id)
+LEFT JOIN patient_diagnosis_assignment paa
+  ON paa.patient_id = p.id
+LEFT JOIN disorder d 
+  ON d.id = paa.disorder_id
+LEFT JOIN et_ophciexamination_diagnoses et_diag
+  ON et_diag.id = paa.element_diagnoses_id
+LEFT JOIN latest_diagnosis_examination_events latest
+  ON latest.event_id = et_diag.event_id
+  AND latest.patient_id = p.id
+LEFT JOIN event e
+  ON e.id = latest.event_id
+LEFT JOIN episode ep
+  ON ep.id = e.episode_id
 WHERE LOWER(d.term) LIKE LOWER(:p_d_value_$this->id)
   AND ep.firm_id = :p_d_firm_$this->id";
         }

--- a/protected/models/PatientDiagnosisParameter.php
+++ b/protected/models/PatientDiagnosisParameter.php
@@ -105,19 +105,19 @@ class PatientDiagnosisParameter extends CaseSearchParameter implements DBProvide
      */
     public function query($searchProvider)
     {
-        $query = "SELECT DISTINCT p.id 
-FROM patient p 
+        $query = "SELECT DISTINCT p.id
+FROM patient p
 LEFT JOIN patient_diagnosis_assignment paa
   ON paa.patient_id = p.id
-LEFT JOIN disorder d 
+LEFT JOIN disorder d
   ON d.id = paa.disorder_id
 WHERE LOWER(d.term) LIKE LOWER(:p_d_value_$this->id)";
         if ($this->firm_id !== '' && $this->firm_id !== null) {
             $query = "SELECT DISTINCT p.id 
-FROM patient p 
+FROM patient p
 LEFT JOIN patient_diagnosis_assignment paa
   ON paa.patient_id = p.id
-LEFT JOIN disorder d 
+LEFT JOIN disorder d
   ON d.id = paa.disorder_id
 LEFT JOIN et_ophciexamination_diagnoses et_diag
   ON et_diag.id = paa.element_diagnoses_id
@@ -136,7 +136,7 @@ WHERE LOWER(d.term) LIKE LOWER(:p_d_value_$this->id)
                 // Do nothing extra.
                 break;
             case 'NOT LIKE':
-                $query = "SELECT DISTINCT p1.id 
+                $query = "SELECT DISTINCT p1.id
 FROM patient p1
 WHERE p1.id NOT IN (
   $query

--- a/protected/models/PatientMedicationParameter.php
+++ b/protected/models/PatientMedicationParameter.php
@@ -99,11 +99,11 @@ class PatientMedicationParameter extends CaseSearchParameter implements DBProvid
                 $wildcard = '%';
 
                 return "
-SELECT p.id 
-FROM patient p 
+SELECT p.id
+FROM patient p
 JOIN patient_medication_assignment m
   ON m.patient_id = p.id
-LEFT JOIN drug d 
+LEFT JOIN drug d
   ON d.id = m.drug_id
 LEFT JOIN medication_drug md
   ON md.id = m.medication_drug_id
@@ -115,11 +115,11 @@ WHERE d.name $op '$wildcard' || :p_m_value_$this->id || '$wildcard'
                 $wildcard = '%';
 
                 return "
-SELECT p.id 
-FROM patient p 
-LEFT JOIN patient_medication_assignment m 
-  ON m.patient_id = p.id 
-LEFT JOIN drug d 
+SELECT p.id
+FROM patient p
+LEFT JOIN patient_medication_assignment m
+  ON m.patient_id = p.id
+LEFT JOIN drug d
   ON d.id = m.drug_id
 LEFT JOIN medication_drug md
   ON md.id = m.medication_drug_id

--- a/protected/models/PatientMedicationParameter.php
+++ b/protected/models/PatientMedicationParameter.php
@@ -101,8 +101,8 @@ class PatientMedicationParameter extends CaseSearchParameter implements DBProvid
                 return "
 SELECT p.id 
 FROM patient p 
-LEFT JOIN medication m 
-  ON m.patient_id = p.id 
+JOIN patient_medication_assignment m
+  ON m.patient_id = p.id
 LEFT JOIN drug d 
   ON d.id = m.drug_id
 LEFT JOIN medication_drug md
@@ -117,7 +117,7 @@ WHERE d.name $op '$wildcard' || :p_m_value_$this->id || '$wildcard'
                 return "
 SELECT p.id 
 FROM patient p 
-LEFT JOIN medication m 
+LEFT JOIN patient_medication_assignment m 
   ON m.patient_id = p.id 
 LEFT JOIN drug d 
   ON d.id = m.drug_id

--- a/protected/modules/OphCiExamination/migrations/m170920_050016_patient_medication_assignment_view.php
+++ b/protected/modules/OphCiExamination/migrations/m170920_050016_patient_medication_assignment_view.php
@@ -1,0 +1,65 @@
+<?php
+
+class m170920_050016_patient_medication_assignment_view extends CDbMigration
+{
+    public function createView($view_name, $select)
+    {
+        $this->dbConnection->createCommand('create view ' . $view_name . ' as ' . $select)->execute();
+    }
+
+    public function dropView($view_name)
+    {
+        $this->dbConnection->createCommand('drop view ' . $view_name)->execute();
+    }
+
+    public function up()
+    {
+        $this->createView('medication_examination_events', <<<EOSQL
+select event_date, event.created_date, event_id, patient_id from et_ophciexamination_history_medications et
+join event on et.event_id = event.id
+join episode on event.episode_id = episode.id
+EOSQL
+        );
+        $this->createView('latest_medication_examination_events', <<<EOSQL
+select t1.event_id, t1.patient_id from medication_examination_events t1
+left outer join medication_examination_events t2
+on t1.patient_id = t2.patient_id
+   and (t1.event_date < t2.event_date
+   		or (t1.event_date = t2.event_date and t1.created_date < t2.created_date))
+where t2.patient_id is null
+EOSQL
+        );
+        $this->createView('patient_medication_assignment', <<<EOSQL
+select
+  aa.id,
+  latest.patient_id as patient_id,
+  aa.drug_id,
+  aa.medication_drug_id,
+  aa.medication_name,
+  aa.dose,
+  aa.units,
+  aa.route_id,
+  aa.option_id,
+  aa.frequency_id,
+  aa.start_date,
+  aa.end_date,
+  aa.stop_reason_id,
+  aa.prescription_item_id,
+  aa.last_modified_user_id,
+  aa.last_modified_date,
+  aa.created_user_id,
+  aa.created_date
+from ophciexamination_history_medications_entry as aa 
+  join et_ophciexamination_history_medications element on aa.element_id = element.id
+  join latest_medication_examination_events latest on element.event_id = latest.event_id
+EOSQL
+        );
+    }
+
+    public function down()
+    {
+        $this->dropView('patient_medication_assignment');
+        $this->dropView('latest_medication_examination_events');
+        $this->dropView('medication_examination_events');
+    }
+}

--- a/protected/modules/OphCiExamination/migrations/m170921_013223_patient_diagnosis_assignment_view.php
+++ b/protected/modules/OphCiExamination/migrations/m170921_013223_patient_diagnosis_assignment_view.php
@@ -1,0 +1,57 @@
+<?php
+
+class m170921_013223_patient_diagnosis_assignment_view extends CDbMigration
+{
+    public function createView($view_name, $select)
+    {
+        $this->dbConnection->createCommand('create view ' . $view_name . ' as ' . $select)->execute();
+    }
+
+    public function dropView($view_name)
+    {
+        $this->dbConnection->createCommand('drop view ' . $view_name)->execute();
+    }
+
+    public function up()
+    {
+        $this->createView('diagnosis_examination_events', <<<EOSQL
+select event_date, event.created_date, event_id, patient_id from et_ophciexamination_diagnoses et
+join event on et.event_id = event.id
+join episode on event.episode_id = episode.id
+EOSQL
+        );
+        $this->createView('latest_diagnosis_examination_events', <<<EOSQL
+select t1.event_id, t1.patient_id from diagnosis_examination_events t1
+left outer join diagnosis_examination_events t2
+on t1.patient_id = t2.patient_id
+   and (t1.event_date < t2.event_date
+   		or (t1.event_date = t2.event_date and t1.created_date < t2.created_date))
+where t2.patient_id is null
+EOSQL
+        );
+        $this->createView('patient_diagnosis_assignment', <<<EOSQL
+select
+  aa.id,
+  latest.patient_id as patient_id,
+  aa.element_diagnoses_id,
+  aa.disorder_id,
+  aa.eye_id,
+  aa.principal,
+  aa.last_modified_user_id,
+  aa.last_modified_date,
+  aa.created_user_id,
+  aa.created_date
+from ophciexamination_diagnosis as aa 
+  join et_ophciexamination_diagnoses element on aa.element_diagnoses_id = element.id
+  join latest_diagnosis_examination_events latest on element.event_id = latest.event_id
+EOSQL
+        );
+    }
+
+    public function down()
+    {
+        $this->dropView('patient_diagnosis_assignment');
+        $this->dropView('latest_diagnosis_examination_events');
+        $this->dropView('diagnosis_examination_events');
+    }
+}

--- a/protected/modules/OphCiExamination/models/OphCiExamination_Diagnosis.php
+++ b/protected/modules/OphCiExamination/models/OphCiExamination_Diagnosis.php
@@ -73,7 +73,7 @@ class OphCiExamination_Diagnosis extends \BaseActiveRecordVersioned
     public function relations()
     {
         return array(
-            'element_diagnoses' => array(self::BELONGS_TO, 'Element_OphCiExamination_Diagnoses', 'element_diagnoses_id'),
+            'element_diagnoses' => array(self::BELONGS_TO, '\OEModule\OphCiExamination\models\Element_OphCiExamination_Diagnoses', 'element_diagnoses_id'),
             'eye' => array(self::BELONGS_TO, 'Eye', 'eye_id'),
             'disorder' => array(self::BELONGS_TO, 'Disorder', 'disorder_id'),
         );

--- a/protected/widgets/PatientDiagnosesAndMedicationsWidget.php
+++ b/protected/widgets/PatientDiagnosesAndMedicationsWidget.php
@@ -2,6 +2,9 @@
 
 class PatientDiagnosesAndMedicationsWidget extends CWidget
 {
+    /**
+     * @var $patient Patient
+     */
     public $patient;
 
 

--- a/protected/widgets/views/patientDiagnosesAndMedicationsWidget.php
+++ b/protected/widgets/views/patientDiagnosesAndMedicationsWidget.php
@@ -32,20 +32,11 @@ foreach ($this->patient->episodes as $episode) {
                             </tr>
                             </thead>
                             <tbody>
-                            <?php foreach ($this->patient->episodes as $episode):
-                                if ($episode->diagnosis !== null): ?>
+                            <?php foreach ($this->patient->diagnoses as $diagnosis):?>
                                 <tr>
-                                    <td><?php echo CHtml::encode($episode->diagnosis->fully_specified_name) . ' (Principal)'; ?></td>
-                                    <td><?php echo CHtml::encode($episode->firm->name); ?></td>
-                                    <td><?php echo $episode->NHSDate('start_date'); ?></td>
-                                </tr>
-                            <?php endif;
-                            endforeach; ?>
-                            <?php foreach ($this->patient->secondarydiagnoses as $diagnosis): ?>
-                                <tr>
-                                    <td><?php echo CHtml::encode($diagnosis->disorder->fully_specified_name) . ' (Secondary)'; ?></td>
-                                    <td>N/A</td>
-                                    <td><?php echo CHtml::encode($diagnosis->dateText); ?></td>
+                                    <td><?php echo CHtml::encode($diagnosis) . ' (' . ($diagnosis->principal == 1 ? 'Principal' : 'Secondary') . ')'; ?></td>
+                                    <td><?php echo CHtml::encode($diagnosis->element_diagnoses->event->episode->firm->getNameAndSubspecialty()); ?></td>
+                                    <td><?php echo CHtml::encode(Helper::convertDate2NHS($diagnosis->element_diagnoses->event->event_date)); ?></td>
                                 </tr>
                             <?php endforeach; ?>
                             </tbody>
@@ -56,7 +47,6 @@ foreach ($this->patient->episodes as $episode) {
         </div>
     </div>
 <?php endif; ?>
-
 
 <?php if ($this->patient->medications): ?>
     <div class="row data-row">
@@ -83,11 +73,8 @@ foreach ($this->patient->episodes as $episode) {
                             <tbody>
                             <?php foreach ($this->patient->medications as $medication): ?>
                                 <tr>
-                                    <td><?php echo $medication->getDrugLabel(); ?></td>
-                                    <td><?= $medication->dose ?>
-                                        <?= isset($medication->route->name) ? $medication->route->name : '' ?>
-                                        <?= $medication->option ? "({$medication->option->name})" : '' ?>
-                                        <?= isset($medication->frequency->name) ? $medication->frequency->name : '' ?></td>
+                                    <td><?php echo $medication->getMedicationDisplay(); ?></td>
+                                    <td><?php echo $medication->getAdministrationDisplay();?></td>
                                     <td><?php echo Helper::formatFuzzyDate($medication->start_date); ?></td>
                                     <td><?php echo isset($medication->end_date) ? Helper::formatFuzzyDate($medication->end_date) : ''; ?></td>
                                 </tr>


### PR DESCRIPTION
Patient Medication and Diagnosis parameters now tap into examination events exclusively for their queries.
Medication and diagnosis table widgets now referring to examination event tables.
Added two new views to gather the current medication and diagnosis assignments from examination events for each patient.
Diagnosis origin now reflected for both principal and secondary diagnoses.
OECaseSearch Subproject commit 8b824ded34f2babcbdd843765d0614601f1136c4 (feature/cera).