### PR TITLE
OE-139 Practice changes and fixes.

### DIFF
--- a/protected/controllers/PatientController.php
+++ b/protected/controllers/PatientController.php
@@ -1723,7 +1723,7 @@ class PatientController extends BaseController
         $gp = isset($patient->gp) ? $patient->gp : null;
         $gp_contact = isset($gp) ? $gp->contact : new Contact();
         $practice = isset($patient->practice) ? $patient->practice : new Practice();
-        $practice_contact = isset($patient->practice) ? $patient-> practice->contact : new Contact();
+        $practice_contact = isset($patient->practice) ? $patient-> practice->contact : new Contact('manage_practice');
         $practice_address = isset($practice_contact) && isset($practice_contact->address) ? $practice_contact->address : new Address();
         $patient_user_referral = isset($patient->patientuserreferral[0]) ? $patient->patientuserreferral[0] : new PatientUserReferral();
         
@@ -1733,8 +1733,8 @@ class PatientController extends BaseController
             $this->redirect(array('view', 'id' => $patient->id));
         }
         
-        $contact = $patient->contact ? $patient->contact : new Contact();
-        $address = $patient->contact->address ? $patient->contact->address : new Address();
+        $contact = $patient->contact ?: new Contact();
+        $address = $patient->contact->address ?: new Address();
         
         switch ($patient->patient_source)
         {

--- a/protected/controllers/PracticeController.php
+++ b/protected/controllers/PracticeController.php
@@ -99,6 +99,9 @@ class PracticeController extends BaseController
     public function performPracticeSave(Contact $contact, Practice $practice, Address $address, $isAjax = false)
     {
         $action = $practice->isNewRecord ? 'add' : 'edit';
+        if (!$practice->code) {
+            $practice->code = 'CERA'; // This will be the same for ALL practices added through the frontend. But only change it if it isn't already set!
+        }
         $transaction = Yii::app()->db->beginTransaction();
         try {
             if ($contact->save()) {

--- a/protected/models/Contact.php
+++ b/protected/models/Contact.php
@@ -69,7 +69,8 @@ class Contact extends BaseActiveRecordVersioned
         return array(
             array('nick_name', 'length', 'max' => 80),
             array('title, first_name, last_name, nick_name, primary_phone, qualifications, maiden_name, contact_label_id', 'safe'),
-            array('first_name, last_name', 'required', 'on' => array('manualAddPatient','referral','self_register','other_register','manage_gp','manage_practice')),
+            array('first_name, last_name', 'required', 'on' => array('manualAddPatient','referral','self_register','other_register','manage_gp',)),
+            array('first_name', 'required', 'on' => array('manage_practice')),
             array('id, nick_name, primary_phone, title, first_name, last_name, qualifications', 'safe', 'on' => 'search'),
         );
     }
@@ -118,7 +119,7 @@ class Contact extends BaseActiveRecordVersioned
             'nick_name' => 'Nickname',
             'primary_phone' => 'Phone number',
             'title' => 'Title',
-            'first_name' => 'First name',
+            'first_name' => $this->scenario === 'manage_practice' ? 'Practice Name' : 'First name',
             'last_name' => 'Last name',
             'qualifications' => 'Qualifications',
             'contact_label_id' => 'Label',

--- a/protected/models/Practice.php
+++ b/protected/models/Practice.php
@@ -80,9 +80,9 @@ class Practice extends BaseActiveRecordVersioned
     public function rules()
     {
         return array(
-            array('code', 'required'),
+            array('code, phone', 'required'),
             array('code','required','on' => 'manage_practice'),
-            array('phone, contact_id', 'safe'),
+            array('contact_id', 'safe'),
             array('id, code', 'safe', 'on' => 'search'),
         );
     }

--- a/protected/views/patient/crud/_form.php
+++ b/protected/views/patient/crud/_form.php
@@ -358,7 +358,7 @@ $ethnic_groups = CHtml::listData(EthnicGroup::model()->findAll(), 'id', 'name');
         <div class="large-offset-4 large-8 column selected_gp end">No result
         </div>
       </div>
-      <div class="right">
+      <div class="large-offset-4 large-8 column">
 
         <p><?php echo CHtml::link('Add Referring Practitioner', '#', array(
                 'onclick' => '$("#gpdialog").dialog("open"); 
@@ -418,7 +418,7 @@ $ethnic_groups = CHtml::listData(EthnicGroup::model()->findAll(), 'id', 'name');
         <div class="large-offset-4 large-8 column selected_practice end">No result
         </div>
       </div>
-      <div class="right">
+      <div class="large-offset-4 large-8 column">
         <p><?php echo CHtml::link('Add Practice', '#', array(
                 'onclick' => '$("#practicedialog").dialog("open"); return false;',
             )); ?>
@@ -497,7 +497,7 @@ $ethnic_groups = CHtml::listData(EthnicGroup::model()->findAll(), 'id', 'name');
                 <?php echo $form->labelEx($referral, 'uploadedFile'); ?>
             </div>
             <div class="large-4 column end">
-                <?php echo $form->fileField($referral, 'uploadedFile'); ?>
+                <p><?php echo $form->fileField($referral, 'uploadedFile'); ?></p>
             </div>
           </div>
         </div>
@@ -569,14 +569,8 @@ $ethnic_groups = CHtml::listData(EthnicGroup::model()->findAll(), 'id', 'name');
     ));
 
     echo CHtml::beginForm(Yii::app()->controller->createUrl('practice/create'), 'post', array('id' => 'practice_form'));
-    echo CHtml::activeLabelEx($practicecontact, 'title');
-    echo CHtml::activeTextField($practicecontact, 'title', array('size' => 30, 'maxlength' => 30));
     echo CHtml::activeLabelEx($practicecontact, 'first_name');
     echo CHtml::activeTextField($practicecontact, 'first_name', array('size' => 30, 'maxlength' => 30));
-    echo CHtml::activeLabelEx($practicecontact, 'last_name');
-    echo CHtml::activeTextField($practicecontact, 'last_name', array('size' => 30, 'maxlength' => 30));
-    echo CHtml::activeLabelEx($practice, 'code');
-    echo CHtml::activeTextField($practice, 'code', array('size' => 30, 'maxlength' => 30));
     echo CHtml::activeLabelEx($practice, 'phone');
     echo CHtml::activeTextField($practice, 'phone', array('size' => 30, 'maxlength' => 30));
     echo '<br>';

--- a/protected/views/practice/_form.php
+++ b/protected/views/practice/_form.php
@@ -1,6 +1,8 @@
 <?php
 /* @var $this PracticeController */
-/* @var $model Contact */
+/* @var $model Practice */
+/* @var $contact Contact */
+/* @var $address Address */
 /* @var $form CActiveForm */
 ?>
 <?php
@@ -24,13 +26,6 @@ $address_type_ids = CHtml::listData(AddressType::model()->findAll(), 'id', 'name
     <div class="row field-row">
         <div class="large-6 column">
             <div class="row field-row">
-                <div class="large-3 column"><?php echo $form->labelEx($contact, 'title'); ?></div>
-                <div class="large-4 column end">
-                    <?php echo $form->textField($contact, 'title', array('size' => 20, 'maxlength' => 20)); ?>
-                    <?php echo $form->error($contact, 'title'); ?>
-                </div>
-            </div>
-            <div class="row field-row">
                 <div class="large-3 column"><?php echo $form->labelEx($contact, 'first_name'); ?></div>
                 <div class="large-4 column end">
                     <?php echo $form->textField($contact, 'first_name', array('size' => 40, 'maxlength' => 100)); ?>
@@ -38,24 +33,10 @@ $address_type_ids = CHtml::listData(AddressType::model()->findAll(), 'id', 'name
                 </div>
             </div>
             <div class="row field-row">
-                <div class="large-3 column"><?php echo $form->labelEx($contact, 'last_name'); ?></div>
+                <div class="large-3 column"><?php echo $form->labelEx($model, 'phone'); ?></div>
                 <div class="large-4 column end">
-                    <?php echo $form->textField($contact, 'last_name', array('size' => 40, 'maxlength' => 100)); ?>
-                    <?php echo $form->error($contact, 'last_name'); ?>
-                </div>
-            </div>
-            <div class="row field-row">
-                <div class="large-3 column"><?php echo $form->labelEx($model, 'code'); ?></div>
-                <div class="large-4 column end">
-                    <?php echo $form->textField($model, 'code', array('size' => 20, 'maxlength' => 64)); ?>
-                    <?php echo $form->error($model, 'code'); ?>
-                </div>
-            </div>
-            <div class="row field-row">
-                <div class="large-3 column"><?php echo $form->labelEx($contact, 'primary_phone'); ?></div>
-                <div class="large-4 column end">
-                    <?php echo $form->telField($contact, 'primary_phone', array('size' => 15, 'maxlength' => 20)); ?>
-                    <?php echo $form->error($contact, 'primary_phone'); ?>
+                    <?php echo $form->telField($model, 'phone', array('size' => 15, 'maxlength' => 64)); ?>
+                    <?php echo $form->error($model, 'phone'); ?>
                 </div>
             </div>
         </div>

--- a/protected/views/practice/index.php
+++ b/protected/views/practice/index.php
@@ -35,7 +35,6 @@ $to = min(($page_num + 1) * $items_per_page, $dataProvider->totalItemCount);
         <tr>
           <th>Practice Contact</th>
           <th>Practice Address</th>
-          <th>Code</th>
           <th>Telephone</th>
         </tr>
         </thead>
@@ -44,7 +43,6 @@ $to = min(($page_num + 1) * $items_per_page, $dataProvider->totalItemCount);
           <tr id="r<?php echo $practice->id; ?>" class="clickable">
             <td><?php echo CHtml::encode($practice->contact->getFullName()); ?></td>
             <td><?php echo CHtml::encode($practice->getAddressLines()); ?></td>
-            <td><?php echo CHtml::encode($practice->code); ?></td>
             <td><?php echo CHtml::encode($practice->phone); ?></td>
           </tr>
         <?php endforeach; ?>

--- a/protected/views/practice/view.php
+++ b/protected/views/practice/view.php
@@ -36,21 +36,11 @@ $this->pageTitle = 'View Practice';
         </div>
         <div class="row data-row">
           <div class="large-3 column">
-            <div class="data-label">Code:</div>
-          </div>
-          <div class="large-3 column end">
-            <div
-                class="data-value"><?php echo CHtml::encode($model->code); ?>
-            </div>
-          </div>
-        </div>
-        <div class="row data-row">
-          <div class="large-3 column">
             <div class="data-label">Phone Number:</div>
           </div>
           <div class="large-3 column end">
             <div
-                class="data-value"><?php echo isset($model->contact->primary_phone) ? CHtml::encode($model->contact->primary_phone) : 'Unknown'; ?></div>
+                class="data-value"><?php echo CHtml::encode($model->phone); ?></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Mandatory fields for practice are now:
* Practice Name (repurposed contact first name).
* Telephone
* Address

Fixed alignment of add Practitioner and Add Practice links on Add Patient screen.
Practice code now internally defaults to CERA (as there is no unique index on this field).
Modified validation so only first name of contact is mandatory for the manage_practice scenario.
Changed attribute label based on whether or not the contact's scenario is manage_practice.
Fixed issue where contact phone number was being filled in when creating practices through the management screens when the (mandatory) practice phone number should be instead.
Converted ternary coalesce assignments to use ?: operator instead of a full ternary operation.