### PR TITLE
OE-278: PHP error in Admin > System >Settings > Therapy Application Sender Email

### DIFF
--- a/protected/modules/OphCoTherapyapplication/migrations/m170711_132400_add_system_setting_therapy_sender.php
+++ b/protected/modules/OphCoTherapyapplication/migrations/m170711_132400_add_system_setting_therapy_sender.php
@@ -4,7 +4,7 @@ class m170711_132400_add_system_setting_therapy_sender extends CDbMigration
 {
     public function up()
     {
-        $this->insert('setting_metadata', array('display_order' => 0, 'field_type_id' => 3, 'key' => 'OphCoTherapyapplication_sender_email', 'name' => 'Therapy Application Sender Email'));
+        $this->insert('setting_metadata', array('display_order' => 0, 'field_type_id' => 4, 'key' => 'OphCoTherapyapplication_sender_email', 'name' => 'Therapy Application Sender Email'));
         $this->insert('setting_installation', array('key' => 'OphCoTherapyapplication_sender_email', 'value' => 'therapyapps@openeyes'));
     }
 


### PR DESCRIPTION
OE-278: Changed the field type of the OphCoTherapyapplication_sender_email setting item from "Radio buttons" to "Text Field"