### PR TITLE
Fixed OE-289: Update patient under "self-registration" model, leave "Email" field empty will raise DOB error

### DIFF
--- a/protected/controllers/PatientController.php
+++ b/protected/controllers/PatientController.php
@@ -1634,12 +1634,6 @@ class PatientController extends BaseController
                         }
                         else {
                             $transaction->rollback();
-                            // to show validation error messages to the user
-                            $patient->validate();
-                            $address->validate();
-                            if (isset($referral)) {
-                                $referral->validate();
-                            }
                         }
                     }
                     else {
@@ -1678,22 +1672,8 @@ class PatientController extends BaseController
                     // patient or address failed to save
                     $transaction->rollback();
 
-                    // to show validation error messages to the user
-                    $patient->validate();
-                    $address->validate();
-                    if (isset($referral)) {
-                        $referral->validate();
-                }
-
                 }
             } else {
-                // to show validation error messages to the user
-                $patient->validate();
-                $address->validate();
-                if (isset($referral)) {
-                    $referral->validate();
-                }
-
                 // remove contact_id validation error
                 $patient->clearErrors('contact_id');
                 $address->clearErrors('contact_id');


### PR DESCRIPTION
Removed unnecessary calls to validate() after a patient fails… saving that caused date format errors to appear (because the user date is massaged into the internal format before save, not before validation)