### PR TITLE
OE-298: OpenEyes Trial Enum Update

### DIFF
--- a/protected/models/Patient.php
+++ b/protected/models/Patient.php
@@ -2055,10 +2055,10 @@ class Patient extends BaseActiveRecordVersioned
     public function isCurrentlyInInterventionTrial($trial_id = null)
     {
         foreach ($this->trials as $trialPatient) {
-            if ((int)$trialPatient->patient_status === TrialPatient::STATUS_ACCEPTED &&
-                (int)$trialPatient->trial->trial_type === Trial::TRIAL_TYPE_INTERVENTION &&
-                (int)$trialPatient->trial->status !== Trial::STATUS_CLOSED &&
-                (int)$trialPatient->trial->status !== Trial::STATUS_CANCELLED &&
+            if ($trialPatient->patient_status === TrialPatient::STATUS_ACCEPTED &&
+                $trialPatient->trial->trial_type === Trial::TRIAL_TYPE_INTERVENTION &&
+                $trialPatient->trial->status !== Trial::STATUS_CLOSED &&
+                $trialPatient->trial->status !== Trial::STATUS_CANCELLED &&
                 ($trial_id === null || $trialPatient->trial_id !== $trial_id)
             ) {
                 return true;


### PR DESCRIPTION
Changed all Trial/TrialPatient/userTrialPermission enums to use strings instead of integers and updated OETrial to commit 37980fd2a50f81e8d26d3c0c44925823864a6c00 (feature/cera)