### PR TITLE
OE-306: Application Error When Saving a Patient with Invalid Address

### DIFF
--- a/protected/controllers/PatientController.php
+++ b/protected/controllers/PatientController.php
@@ -1584,6 +1584,7 @@ class PatientController extends BaseController
     */
    private function performPatientSave(Contact $contact, Patient $patient, Address $address, PatientReferral $referral, PatientUserReferral $patient_user_referral)
    {
+        $patientScenario = $patient->getScenario();
         $transaction = Yii::app()->db->beginTransaction();
         try{
             if( $contact->save() ){
@@ -1686,6 +1687,7 @@ class PatientController extends BaseController
             $transaction->rollback();
         }
         
+        $patient->setScenario($patientScenario);
         return array($contact, $patient, $address, $referral, $patient_user_referral);
    }
    


### PR DESCRIPTION
Fixed an issue where saving a new patient with a correct Patient model but an incorrect address would cause the patient scenario to change to 'update', causing an exception during the screen render