### PR TITLE
OE-294: "Pending Therapy Applications Report" throwing error

### DIFF
--- a/protected/modules/OphCoTherapyapplication/controllers/ReportController.php
+++ b/protected/modules/OphCoTherapyapplication/controllers/ReportController.php
@@ -333,12 +333,17 @@ class ReportController extends BaseReportController
     public function actionPendingApplications()
     {
         $sent = false;
+        $error_message = null;
 
         if (Yii::app()->getRequest()->getQuery('report') === 'generate') {
-            $pendingApplications = new PendingApplications();
-            $sent = $pendingApplications->emailCsvFile(Yii::app()->params['applications_alert_recipients']);
+            try {
+                $pendingApplications = new PendingApplications();
+                $sent = $pendingApplications->emailCsvFile(Yii::app()->params['applications_alert_recipients']);
+            } catch (Exception $ex) {
+                $error_message = $ex->getMessage();
+            }
         }
 
-        $this->render('pending_applications', array('sent' => $sent));
+        $this->render('pending_applications', array('sent' => $sent, 'error_message' => $error_message));
     }
 }

--- a/protected/modules/OphCoTherapyapplication/views/report/pending_applications.php
+++ b/protected/modules/OphCoTherapyapplication/views/report/pending_applications.php
@@ -1,12 +1,24 @@
+<?php
+/* @var boolean $sent */
+/* @var string $error_message */
+?>
+
 <div class="box reports">
-    <div class="report-fields">
-        <h2>Pending Therapy Applications Report</h2>
-        <?php if ($sent):?>
-            <span>Report sent</span>
-        <?php else:?>
-            <form>
-                <button type="submit" name="report" value="generate">Generate</button>
-            </form>
-        <?php endif;?>
-    </div>
+  <div class="report-fields">
+    <h2>Pending Therapy Applications Report</h2>
+      <?php if ($sent): ?>
+        <span>Report sent</span>
+      <?php else: ?>
+        <form>
+          <button type="submit" name="report" value="generate">Generate</button>
+        </form>
+          <?php if ($error_message !== null): ?>
+          <div class="alert-box alert with-icon">
+            <p>An error occurred when sending the report: <br/>
+              <strong><?php echo $error_message; ?></strong></p>
+            <p>Please contact an administrator. The "Therapy Applications Alert Recipients" setting may be incorrect.</p>
+          </div>
+          <?php endif; ?>
+      <?php endif; ?>
+  </div>
 </div>


### PR DESCRIPTION
Made the "Pending Therapy Applications" swallow any exceptions that are raised when sending the report via email, and to display the exception message to the user.