### PR TITLE
OE-318 prevented erroneous redirect to edit the only contact in admin

### DIFF
--- a/protected/controllers/AdminController.php
+++ b/protected/controllers/AdminController.php
@@ -692,7 +692,7 @@ class AdminController extends BaseAdminController
 
         $contacts = Contact::model()->findAll($criteria);
 
-        if (count($contacts) == 1) {
+        if (@$_GET['q'] !== '' && @$_GET['q'] !== null && count($contacts) == 1) {
             foreach ($contacts as $contact) {
             }
             $this->redirect(array('/admin/editContact?contact_id=' . $contact->id));

--- a/protected/views/admin/contacts.php
+++ b/protected/views/admin/contacts.php
@@ -55,15 +55,7 @@
 		handleButton($('#et_search'),function(e) {
 			e.preventDefault();
 			if ($('#q').val().length <1) {
-				new OpenEyes.UI.Dialog.Alert({
-					content: "Please enter a search term"
-				})
-				.on('close', function() {
-					enableButtons();
-					$('#q').focus;
-				})
-				.open();
-				enableButtons();
+        window.location.href = baseUrl+'/admin/contacts';
 			} else {
 				window.location.href = baseUrl+'/admin/contacts?q='+$('#q').val()+'&label='+$('#label').val();
 			}


### PR DESCRIPTION
To test:
SET FOREIGN_KEY_CHECKS = 0;
DELETE FROM contact WHERE id != 1;
SET FOREIGN_KEY_CHECKS = 1;

I also changed a useless message that shows when you remove the search criteria and try to search. Now it just redirects you to the page without a search