### PR TITLE
OE-319-patient-source-default-to-referral

### DIFF
--- a/protected/controllers/PatientController.php
+++ b/protected/controllers/PatientController.php
@@ -1492,7 +1492,7 @@ class PatientController extends BaseController
         Yii::app()->assetManager->registerScriptFile('js/patient.js');
         //Don't render patient summary box on top as we have no selected patient
         $this->renderPatientPanel = false;
-        $patient_source ='other_register';
+        $patient_source ='referral';
         $patient = new Patient($patient_source);
         $patient->noPas();
         $contact = new Contact('manualAddPatient');


### PR DESCRIPTION
Change the default patient source to "referral".

BTW, has anyone noticed that whichever default patient source I set, the "other" option is always selected as well after loading the page, which is weird and I don't know why.
If anyone can figure this out it will be great.