### PR TITLE
OE-317 Secondary diagnosis in Case Search

### DIFF
--- a/protected/modules/OphCiExamination/models/PatientDiagnosisParameter.php
+++ b/protected/modules/OphCiExamination/models/PatientDiagnosisParameter.php
@@ -124,7 +124,17 @@ JOIN patient_systemic_diagnosis psd
   ON psd.patient_id = p2.id
 JOIN disorder d2
   ON d2.id = psd.disorder_id
-WHERE LOWER(d2.term) LIKE LOWER(:p_d_value_$this->id)";
+WHERE LOWER(d2.term) LIKE LOWER(:p_d_value_$this->id)
+
+UNION
+
+SELECT DISTINCT p3.id
+FROM patient p3 
+JOIN secondary_diagnosis sd
+  ON sd.patient_id = p3.id
+JOIN disorder d3
+  ON d3.id = sd.disorder_id
+WHERE LOWER(d3.term) LIKE LOWER(:p_d_value_$this->id)";
         if ($this->firm_id !== '' && $this->firm_id !== null) {
             $query = "SELECT DISTINCT p.id 
 FROM patient p

--- a/protected/widgets/views/patientDiagnosesAndMedicationsWidget.php
+++ b/protected/widgets/views/patientDiagnosesAndMedicationsWidget.php
@@ -33,6 +33,13 @@
                                     <td><?php echo $diagnosis->element->event ? CHtml::encode(Helper::convertDate2NHS($diagnosis->element->event->event_date)) : 'Unknown'; ?></td>
                                 </tr>
                             <?php endforeach; ?>
+                            <?php foreach ($this->patient->secondarydiagnoses as $diagnosis): ?>
+                                <tr>
+                                    <td><?php echo CHtml::encode($diagnosis->getSystemicDescription()) . ' (Secondary)'; ?></td>
+                                    <td>Unknown</td>
+                                    <td><?php echo $diagnosis->getDateText() ? CHtml::encode($diagnosis->getDateText()) : 'Unknown'; ?></td>
+                                </tr>
+                            <?php endforeach; ?>
                             </tbody>
                         </table>
                     </div>


### PR DESCRIPTION
Re-added secondary diagnoses to case search parameter query.
Re-added secondary diagnoses to patient diagnoses widget. This may result in duplicated diagnoses between events and manually added secondary diagnoses, so testing must be rigorous.