### PR TITLE
OE-338:  Patient Diagnoses Display Issues

### DIFF
--- a/protected/views/patient/_130_diagnoses.php
+++ b/protected/views/patient/_130_diagnoses.php
@@ -39,7 +39,6 @@
 				<th>Diagnosis</th>
 				<?php if ($this->checkAccess('OprnEditOtherOphDiagnosis')) { ?>
 					<th>Actions</th>
-                    <th></th>
 				<?php } ?>
 			</tr>
 			</thead>

--- a/protected/views/patient/_systemic_diagnoses.php
+++ b/protected/views/patient/_systemic_diagnoses.php
@@ -40,20 +40,15 @@
 			</tr>
 			</thead>
 			<tbody>
-      <?php foreach ($this->patient->systemicDiagnoses as $diagnosis) { ?>
-        <tr>
-          <td><?php echo $diagnosis->dateText ?></td>
-          <td>
-              <?php echo $diagnosis->eye ? $diagnosis->eye->adjective : '' ?>
-              <?php echo $diagnosis->disorder->term ?>
-          </td>
-            <?php if ($this->checkAccess('OprnEditSystemicDiagnosis')) { ?>
-              <td>
-                <a href="#" class="removeDiagnosis" rel="<?php echo $diagnosis->id ?>">Remove</a>
-              </td>
-            <?php } ?>
-        </tr>
-      <?php } ?>
+			<?php foreach ($this->patient->systemicDiagnoses as $diagnosis) {?>
+				<tr>
+					<td><?php echo $diagnosis->dateText?></td>
+					<td><?php echo $diagnosis->eye ? $diagnosis->eye->adjective : ''?> <?php echo $diagnosis->disorder->term?></td>
+					<?php if ($this->checkAccess('OprnEditSystemicDiagnosis')) { ?>
+						<td><a href="#" class="removeDiagnosis" rel="<?php echo $diagnosis->id?>">Remove</a></td>
+					<?php } ?>
+				</tr>
+			<?php }?>
 			</tbody>
 		</table>
 


### PR DESCRIPTION
Removed an empty <th> that caused display issues for patient ophthalmic diagnoses, and reverted all changes made to systemic_diagnoses view as part of the diagnosis confirmation story