### PR TITLE
OE-369 Unable to Delete Workflows

### DIFF
--- a/protected/modules/OphCiExamination/views/admin/list_OphCiExamination_Workflow.php
+++ b/protected/modules/OphCiExamination/views/admin/list_OphCiExamination_Workflow.php
@@ -54,7 +54,7 @@
 				<tr>
 					<td colspan="5">
 						<?php echo EventAction::button('Add', 'add', null, array('class' => 'small', 'data-uri' => '/OphCiExamination/admin/addWorkflow'))->toHtml()?>
-						<?php echo EventAction::button('Delete', 'delete', null, array('class' => 'small', 'data-uri' => '/OphCiExamination/admin/deleteWorkflows', 'data-object' => 'email_recipients'))->toHtml()?>
+						<?php echo EventAction::button('Delete', 'delete', null, array('class' => 'small', 'data-uri' => '/OphCiExamination/admin/deleteWorkflows', 'data-object' => 'workflows'))->toHtml()?>
 					</td>
 				</tr>
 			</tfoot>


### PR DESCRIPTION
Fixed issue where data-object attribute on the workflow delete button was referencing a Therapy Application object, preventing workflows from being deleted.