### PR TITLE
OE-374, fix the audit page be empty error for most users

### DIFF
--- a/protected/controllers/AuditController.php
+++ b/protected/controllers/AuditController.php
@@ -28,18 +28,13 @@ class AuditController extends BaseController
     {
         return array(
             array('allow',
-                'roles' => array('OprnViewClinical'),
+                'roles' => array('admin'),
             ),
         );
     }
 
     public function beforeAction($action)
     {
-        Yii::app()->assetManager->registerScriptFile('js/audit.js');
-        $userid = Yii::app()->session['user']->id;
-        if (($userid != 2103) and ($userid != 122) and ($userid != 613) and ($userid != 1330) and ($userid != 1)) {
-            return false;
-        }
 
         Yii::app()->assetManager->registerScriptFile('js/audit.js');
 


### PR DESCRIPTION
1. Remove the hardcoded userid in beforAction() function, 
2. Change access rule from "OprnViewClinical" to "admin"