### PR TITLE
OE-378, add Report restrict to cantaract in config file

### DIFF
--- a/protected/config/core/common.php
+++ b/protected/config/core/common.php
@@ -321,7 +321,7 @@ return array(
                 'uri' => 'dashboard/cataract',
                 'position' => 4,
                 'userrule' => 'isSurgeon',
-                'restricted' => array('admin'),
+                'restricted' => array('admin,Report'),
                 'options' => array('target' => '_blank'),),
             'nodexport' => array(
                 'title' => 'NOD Export',


### PR DESCRIPTION
Add Report restrict to cataract audit, can hide the "cataract audit" link in menu bar when user don't have report role.
Avoid the cataract audit page cannot load problem.