### PR TITLE
OE-381, remove add button of systemic and ophthalmic diagnoses from patient summary

### DIFF
--- a/protected/views/patient/_130_diagnoses.php
+++ b/protected/views/patient/_130_diagnoses.php
@@ -63,11 +63,6 @@
 		</table>
 
 		<?php if ($this->checkAccess('OprnEditOtherOphDiagnosis')) { ?>
-			<div class="box-actions">
-				<button id='btn-add_new_ophthalmic_diagnosis' class="secondary small">
-					Add Ophthalmic Diagnosis
-				</button>
-			</div>
 
 			<div id="add_new_ophthalmic_diagnosis" style="display: none;">
 
@@ -84,7 +79,6 @@
                         'class' => 'form add-data',
                     ),
                 ))?>
-
 					<fieldset class="field-row">
 
 						<legend><strong>Add ophthalmic diagnosis</strong></legend>

--- a/protected/views/patient/_systemic_diagnoses.php
+++ b/protected/views/patient/_systemic_diagnoses.php
@@ -53,14 +53,7 @@
 		</table>
 
 		<?php if ($this->checkAccess('OprnEditSystemicDiagnosis')) { ?>
-			<div class="box-actions">
-				<button id="btn-add_new_systemic_diagnosis" class="secondary small">
-					Add Systemic Diagnosis
-				</button>
-			</div>
-
 			<div id="add_new_systemic_diagnosis" style="display: none;">
-
 				<?php
                 $form = $this->beginWidget('FormLayout', array(
                         'id' => 'add-systemic-diagnosis',


### PR DESCRIPTION
Remove add new button of ophthalmic/systemic diagnoses on patient summary.
We might want to decide if need to remove all the related functions and form widgets, which might cause confusion later.