### PR TITLE
OEA-385: Event Context Should be Stored and Displayed

### DIFF
--- a/protected/controllers/BaseEventTypeController.php
+++ b/protected/controllers/BaseEventTypeController.php
@@ -806,6 +806,8 @@ class BaseEventTypeController extends BaseModuleController
      */
     public function actionCreate()
     {
+        $this->event->firm_id = $this->selectedFirmId;
+        
         if (!empty($_POST)) {
             // form has been submitted
             if (isset($_POST['cancel'])) {

--- a/protected/migrations/m171109_022117_add_firm_id_to_event.php
+++ b/protected/migrations/m171109_022117_add_firm_id_to_event.php
@@ -1,0 +1,19 @@
+<?php
+
+class m171109_022117_add_firm_id_to_event extends OEMigration
+{
+    public function safeUp()
+    {
+        $this->addColumn('event', 'firm_id', 'int(10) unsigned');
+        $this->addColumn('event_version', 'firm_id', 'int(10) unsigned');
+
+        $this->addForeignKey('event_firm_fk', 'event', 'firm_id', 'firm', 'id');
+    }
+
+    public function safeDown()
+    {
+        $this->dropForeignKey('event_firm_fk', 'event');
+        $this->dropColumn('event', 'firm_id');
+        $this->dropColumn('event_version', 'firm_id');
+    }
+}

--- a/protected/models/Event.php
+++ b/protected/models/Event.php
@@ -122,6 +122,7 @@ class Event extends BaseActiveRecordVersioned
             'issues' => array(self::HAS_MANY, 'EventIssue', 'event_id'),
             'parent' => array(self::BELONGS_TO, 'Event', 'parent_id'),
             'children' => array(self::HAS_MANY, 'Event', 'parent_id'),
+            'firm' => array(self::BELONGS_TO, 'Firm', 'firm_id'),
         );
     }
 

--- a/protected/modules/OphCiExamination/models/PatientDiagnosisParameter.php
+++ b/protected/modules/OphCiExamination/models/PatientDiagnosisParameter.php
@@ -65,7 +65,7 @@ class PatientDiagnosisParameter extends CaseSearchParameter implements DBProvide
             'LIKE' => 'Diagnosed with',
             'NOT LIKE' => 'Not diagnosed with',
         );
-        
+
         $firms = Firm::model()->getListWithSpecialties()
         ?>
       <div class="row field-row">
@@ -169,7 +169,7 @@ AND (:p_d_only_latest_event_$this->id = 0 OR
     AND later_event.event_date > event.event_date OR (later_event.event_date = event.event_date AND later_event.created_date > event.created_date)
   )
 )";
-        if ($this->firm_id !== '' && $this->firm_id !== null && $this->only_latest_event == 0) {
+        if (($this->firm_id === '' || $this->firm_id === null) && $this->only_latest_event == 0) {
             $query .= ' UNION ';
             $query .= "SELECT p3.id
 FROM patient p3 

--- a/protected/modules/OphCiExamination/models/PatientDiagnosisParameter.php
+++ b/protected/modules/OphCiExamination/models/PatientDiagnosisParameter.php
@@ -65,9 +65,8 @@ class PatientDiagnosisParameter extends CaseSearchParameter implements DBProvide
             'LIKE' => 'Diagnosed with',
             'NOT LIKE' => 'Not diagnosed with',
         );
-        $firmModel = new Firm();
-
-        $firms = $firmModel->getListWithSpecialties();
+        
+        $firms = Firm::model()->getListWithSpecialties()
         ?>
       <div class="row field-row">
         <div class="large-2 column">
@@ -138,7 +137,7 @@ JOIN event ON event.id = diagnoses.event_id
 JOIN episode ON episode.id = event.episode_id
 JOIN disorder ON diagnosis.disorder_id = disorder.id
 WHERE LOWER(disorder.term) LIKE LOWER(:p_d_value_$this->id)
-AND (:p_d_firm_$this->id IS NULL OR episode.firm_id = :p_d_firm_$this->id)
+AND (:p_d_firm_$this->id IS NULL OR event.firm_id = :p_d_firm_$this->id)
 AND (:p_d_only_latest_event_$this->id = 0 OR
   NOT EXISTS (
     SELECT true
@@ -159,7 +158,7 @@ JOIN event ON event.id = diagnoses.event_id
 JOIN episode ON episode.id = event.episode_id
 JOIN disorder ON diagnosis.disorder_id = disorder.id
 WHERE LOWER(disorder.term) LIKE LOWER(:p_d_value_$this->id)
-AND (:p_d_firm_$this->id IS NULL OR episode.firm_id = :p_d_firm_$this->id)
+AND (:p_d_firm_$this->id IS NULL OR event.firm_id = :p_d_firm_$this->id)
 AND (:p_d_only_latest_event_$this->id = 0 OR
   NOT EXISTS (
     SELECT true

--- a/protected/tests/fixtures/event.php
+++ b/protected/tests/fixtures/event.php
@@ -30,6 +30,7 @@ return array(
         'deleted' => false,
         'delete_reason' => null,
         'delete_pending' => false,
+        'firm_id' => 2,
     ),
     'event2' => array(
         'id' => 2,
@@ -44,6 +45,7 @@ return array(
         'deleted' => false,
         'delete_reason' => null,
         'delete_pending' => false,
+        'firm_id' => 2,
     ),
     'event3' => array(
         'id' => 3,
@@ -100,6 +102,7 @@ return array(
         'deleted' => false,
         'delete_reason' => null,
         'delete_pending' => false,
+        'firm_id' => 2,
     ),
     'event7' => array(
         'id' => 7,
@@ -263,6 +266,7 @@ return array(
         'deleted' => false,
         'delete_reason' => null,
         'delete_pending' => false,
+        'firm_id' => 2,
     ),
     'event19' => array(
         'episode_id' => 8,
@@ -317,6 +321,7 @@ return array(
         'deleted' => false,
         'delete_reason' => null,
         'delete_pending' => false,
+        'firm_id' => 2,
     ),
     'event23' => array(
         'episode_id' => 10,
@@ -330,6 +335,7 @@ return array(
         'deleted' => false,
         'delete_reason' => null,
         'delete_pending' => false,
+        'firm_id' => 3,
     ),
 
 );

--- a/protected/tests/fixtures/patient.php
+++ b/protected/tests/fixtures/patient.php
@@ -60,6 +60,7 @@ return array(
         'contact_id' => 3,
     ),
     'patient4' => array(
+        'id' => 4,
         'pas_key' => '123',
         'title' => 'Mrs.',
         'first_name' => 'Carla',
@@ -74,6 +75,7 @@ return array(
         'contact_id' => 4,
     ),
     'patient5' => array(
+        'id' => 5,
         'pas_key' => '1010',
         'title' => 'Mrs',
         'first_name' => 'Carla',
@@ -88,6 +90,7 @@ return array(
         'contact_id' => 5,
     ),
     'patient6' => array(
+        'id' => 6,
         'pas_key' => '10107',
         'title' => 'Mrs',
         'first_name' => 'Carla',

--- a/protected/views/patient/event_content.php
+++ b/protected/views/patient/event_content.php
@@ -10,7 +10,7 @@
 	</header>
     <div class="event-content <?=($this->event->is_automated) ? 'auto' : ''?>" id="event-content">
 
-		<h2 class="event-title <?=($this->event->is_automated) ? 'auto' : ''?>" style="background-image: url('<?=$this->event->getEventIcon('medium')?>');"><?php echo $this->title?> <?php $this->renderPartial('//patient/event_automated'); ?></h2>
+		<h2 class="event-title <?=($this->event->is_automated) ? 'auto' : ''?>" style="background-image: url('<?=$this->event->getEventIcon('medium')?>');"><?php echo $this->title?> <?php echo $this->event->firm ? ' &mdash; Created under ' . $this->event->firm->name : null; ?> <?php $this->renderPartial('//patient/event_automated'); ?></h2>
 
 		<?php $this->renderPartial('//base/_messages'); ?>
 


### PR DESCRIPTION
Changed events to have a firm_id column that is set to the context that the user selected when they created the event, and changed the diagnosis parameter to search on that relationship