### PR TITLE
OE-375 Add letter types

### DIFF
--- a/protected/modules/OphCoCorrespondence/controllers/oeadmin/LetterTypeController.php
+++ b/protected/modules/OphCoCorrespondence/controllers/oeadmin/LetterTypeController.php
@@ -64,7 +64,7 @@ class LetterTypeController extends ModuleAdminController
             $admin->setModelId($id);
         }
         $admin->setEditFields(array(
-            'name' => 'label',
+            'name' => 'text',
             'is_active' => 'checkbox',
         ));
         $admin->editModel();


### PR DESCRIPTION
Re-enabled the letter type name field on the Add/Edit Letter Type form.
NOTE: The internal referral letter type should not be changed or it may cause issues with internal referral correspondence events.