### PR TITLE
OEA-436 Firm to Context

### DIFF
--- a/protected/models/User.php
+++ b/protected/models/User.php
@@ -236,7 +236,7 @@ class User extends BaseActiveRecordVersioned
             'password_old' => 'Current password',
             'password_new' => 'New password',
             'password_confirm' => 'Confirm password',
-            'global_firm_rights' => 'Global firm rights',
+            'global_firm_rights' => 'Global ' . strtolower(Firm::contextLabel()) . ' rights',
             'is_doctor' => 'Doctor',
             'is_consultant' => 'Consultant',
             'is_clinical' => 'Clinically trained',

--- a/protected/views/admin/edituser.php
+++ b/protected/views/admin/edituser.php
@@ -56,7 +56,7 @@
         'id',
         CHtml::listData(Firm::model()->findAll(), 'id', 'name'),
         array(),
-        array('label' => 'Firms', 'empty' => '-- Add --')
+        array('label' => Firm::contextLabel() . 's', 'empty' => '-- Add --')
     ); ?>
 
 


### PR DESCRIPTION
Replaced usage of word Firm on the Edit user screen with the context label specified under Admin->Settings.